### PR TITLE
feat: support multiple payers per expense

### DIFF
--- a/prisma/migrations/20250822103414_add_expense_payers/migration.sql
+++ b/prisma/migrations/20250822103414_add_expense_payers/migration.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "ExpensePayer" (
+  "expenseId" TEXT NOT NULL,
+  "participantId" TEXT NOT NULL,
+  "amount" INTEGER NOT NULL,
+  CONSTRAINT "ExpensePayer_pkey" PRIMARY KEY ("expenseId", "participantId"),
+  CONSTRAINT "ExpensePayer_expenseId_fkey" FOREIGN KEY ("expenseId") REFERENCES "Expense"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "ExpensePayer_participantId_fkey" FOREIGN KEY ("participantId") REFERENCES "Participant"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ model Participant {
   groupId         String
   expensesPaidBy  Expense[]
   expensesPaidFor ExpensePaidFor[]
+  expensesContributed ExpensePayer[]
 }
 
 model Category {
@@ -48,6 +49,7 @@ model Expense {
   amount          Int
   paidBy          Participant       @relation(fields: [paidById], references: [id], onDelete: Cascade)
   paidById        String
+  payers          ExpensePayer[]
   paidFor         ExpensePaidFor[]
   groupId         String
   isReimbursement Boolean           @default(false)
@@ -106,6 +108,16 @@ model ExpensePaidFor {
   expenseId     String
   participantId String
   shares        Int         @default(1)
+
+  @@id([expenseId, participantId])
+}
+
+model ExpensePayer {
+  expense       Expense     @relation(fields: [expenseId], references: [id], onDelete: Cascade)
+  participant   Participant @relation(fields: [participantId], references: [id], onDelete: Cascade)
+  expenseId     String
+  participantId String
+  amount        Int
 
   @@id([expenseId, participantId])
 }

--- a/src/app/groups/[groupId]/expenses/expense-card.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-card.tsx
@@ -22,9 +22,13 @@ function Participants({ expense }: { expense: Expense }) {
       <strong>{paidFor.participant.name}</strong>
     </Fragment>
   ))
+  const paidByNames =
+    expense.payers.length > 0
+      ? expense.payers.map((p) => p.participant.name).join(', ')
+      : expense.paidBy.name
   const participants = t.rich(key, {
     strong: (chunks) => <strong>{chunks}</strong>,
-    paidBy: expense.paidBy.name,
+    paidBy: paidByNames,
     paidFor: () => paidFor,
     forCount: expense.paidFor.length,
   })

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -158,20 +158,19 @@ export function ExpenseForm({
   const isCreate = expense === undefined
   const searchParams = useSearchParams()
 
-  const getSelectedPayer = (field?: { value: string }) => {
-    if (isCreate && typeof window !== 'undefined') {
-      const activeUser = localStorage.getItem(`${group.id}-activeUser`)
-      if (activeUser && activeUser !== 'None' && field?.value === undefined) {
-        return activeUser
-      }
-    }
-    return field?.value
-  }
-
   const getSelectedRecurrenceRule = (field?: { value: string }) => {
     return field?.value as RecurrenceRule
   }
   const defaultSplittingOptions = getDefaultSplittingOptions(group)
+  const getDefaultPayerId = () => {
+    if (isCreate && typeof window !== 'undefined') {
+      const activeUser = localStorage.getItem(`${group.id}-activeUser`)
+      if (activeUser && activeUser !== 'None') {
+        return activeUser
+      }
+    }
+    return undefined
+  }
   const form = useForm<ExpenseFormValues>({
     resolver: zodResolver(expenseFormSchema),
     defaultValues: expense
@@ -180,7 +179,18 @@ export function ExpenseForm({
           expenseDate: expense.expenseDate ?? new Date(),
           amount: String(expense.amount / 100) as unknown as number, // hack
           category: expense.categoryId,
-          paidBy: expense.paidById,
+          payers:
+            expense.payers.length > 0
+              ? expense.payers.map(({ participant, amount }) => ({
+                  participant: participant.id,
+                  amount: String(amount / 100) as unknown as number,
+                }))
+              : [
+                  {
+                    participant: expense.paidById,
+                    amount: String(expense.amount / 100) as unknown as number,
+                  },
+                ],
           paidFor: expense.paidFor.map(({ participantId, shares }) => ({
             participant: participantId,
             shares: String(shares / 100) as unknown as number,
@@ -200,7 +210,14 @@ export function ExpenseForm({
             (Number(searchParams.get('amount')) || 0) / 100,
           ) as unknown as number, // hack
           category: 1, // category with Id 1 is Payment
-          paidBy: searchParams.get('from') ?? undefined,
+          payers: [
+            {
+              participant: searchParams.get('from') ?? '',
+              amount: String(
+                (Number(searchParams.get('amount')) || 0) / 100,
+              ) as unknown as number,
+            },
+          ],
           paidFor: [
             searchParams.get('to')
               ? {
@@ -227,7 +244,12 @@ export function ExpenseForm({
             : 0, // category with Id 0 is General
           // paid for all, split evenly
           paidFor: defaultSplittingOptions.paidFor,
-          paidBy: getSelectedPayer(),
+          payers: [
+            {
+              participant: getDefaultPayerId() ?? '',
+              amount: (searchParams.get('amount') || 0) as unknown as number,
+            },
+          ],
           isReimbursement: false,
           splitMode: defaultSplittingOptions.splitMode,
           saveDefaultSplittingOptions: false,
@@ -465,34 +487,6 @@ export function ExpenseForm({
 
             <FormField
               control={form.control}
-              name="paidBy"
-              render={({ field }) => (
-                <FormItem className="sm:order-5">
-                  <FormLabel>{t(`${sExpense}.paidByField.label`)}</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={getSelectedPayer(field)}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select a participant" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {group.participants.map(({ id, name }) => (
-                        <SelectItem key={id} value={id}>
-                          {name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormDescription>
-                    {t(`${sExpense}.paidByField.description`)}
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
               name="notes"
               render={({ field }) => (
                 <FormItem className="sm:order-6">
@@ -537,6 +531,126 @@ export function ExpenseForm({
                     {t(`${sExpense}.recurrenceRule.description`)}
                   </FormDescription>
                   <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+        </Card>
+
+        <Card className="mt-4">
+          <CardHeader>
+            <CardTitle>{t(`${sExpense}.paidByField.label`)}</CardTitle>
+            <CardDescription>
+              {t(`${sExpense}.paidByField.description`)}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <FormField
+              control={form.control}
+              name="payers"
+              render={() => (
+                <FormItem className="sm:order-5 row-span-2 space-y-0">
+                  {group.participants.map(({ id, name }) => (
+                    <FormField
+                      key={id}
+                      control={form.control}
+                      name="payers"
+                      render={({ field }) => {
+                        const index = field.value.findIndex(
+                          (p: { participant: string }) => p.participant === id,
+                        )
+                        const checked = index !== -1
+                        return (
+                          <div
+                            data-id={`${id}`}
+                            className="flex items-center border-t last-of-type:border-b -mx-6 px-6 py-3"
+                          >
+                            <FormItem className="flex-1 flex flex-row items-start space-x-3 space-y-0">
+                              <FormControl>
+                                <Checkbox
+                                  checked={checked}
+                                  onCheckedChange={(c) => {
+                                    const options = {
+                                      shouldDirty: true,
+                                      shouldTouch: true,
+                                      shouldValidate: true,
+                                    }
+                                    c
+                                      ? form.setValue(
+                                          'payers',
+                                          [
+                                            ...field.value,
+                                            {
+                                              participant: id,
+                                              amount: '0' as unknown as number,
+                                            },
+                                          ],
+                                          options,
+                                        )
+                                      : form.setValue(
+                                          'payers',
+                                          field.value.filter(
+                                            (v: { participant: string }) =>
+                                              v.participant !== id,
+                                          ),
+                                          options,
+                                        )
+                                  }}
+                                />
+                              </FormControl>
+                              <FormLabel className="text-sm font-normal flex-1">
+                                {name}
+                              </FormLabel>
+                            </FormItem>
+                            {checked && (
+                              <FormField
+                                name={`payers[${index}].amount` as const}
+                                render={() => (
+                                  <FormControl>
+                                    <Input
+                                      className="text-base w-24"
+                                      type="text"
+                                      inputMode="decimal"
+                                      value={field.value[index].amount}
+                                      onChange={(event) => {
+                                        const options = {
+                                          shouldDirty: true,
+                                          shouldTouch: true,
+                                          shouldValidate: true,
+                                        }
+                                        form.setValue(
+                                          'payers',
+                                          field.value.map(
+                                            (
+                                              p: {
+                                                participant: string
+                                                amount: any
+                                              },
+                                              i: number,
+                                            ) =>
+                                              i === index
+                                                ? {
+                                                    participant: p.participant,
+                                                    amount:
+                                                      enforceCurrencyPattern(
+                                                        event.target.value,
+                                                      ),
+                                                  }
+                                                : p,
+                                          ),
+                                          options,
+                                        )
+                                      }}
+                                    />
+                                  </FormControl>
+                                )}
+                              />
+                            )}
+                          </div>
+                        )
+                      }}
+                    />
+                  ))}
                 </FormItem>
               )}
             />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -41,7 +41,7 @@ export async function createExpense(
   if (!group) throw new Error(`Invalid group ID: ${groupId}`)
 
   for (const participant of [
-    expenseFormValues.paidBy,
+    ...expenseFormValues.payers.map((p) => p.participant),
     ...expenseFormValues.paidFor.map((p) => p.participant),
   ]) {
     if (!group.participants.some((p) => p.id === participant))
@@ -71,7 +71,13 @@ export async function createExpense(
       categoryId: expenseFormValues.category,
       amount: expenseFormValues.amount,
       title: expenseFormValues.title,
-      paidById: expenseFormValues.paidBy,
+      paidById: expenseFormValues.payers[0].participant,
+      payers: {
+        create: expenseFormValues.payers.map((payer) => ({
+          participantId: payer.participant,
+          amount: payer.amount,
+        })),
+      },
       splitMode: expenseFormValues.splitMode,
       recurrenceRule: expenseFormValues.recurrenceRule,
       recurringExpenseLink: {
@@ -128,7 +134,9 @@ export async function getGroupExpensesParticipants(groupId: string) {
   return Array.from(
     new Set(
       expenses.flatMap((e) => [
-        e.paidBy.id,
+        ...(e.payers.length
+          ? e.payers.map((p) => p.participant.id)
+          : [e.paidBy.id]),
         ...e.paidFor.map((pf) => pf.participant.id),
       ]),
     ),
@@ -160,7 +168,7 @@ export async function updateExpense(
   if (!existingExpense) throw new Error(`Invalid expense ID: ${expenseId}`)
 
   for (const participant of [
-    expenseFormValues.paidBy,
+    ...expenseFormValues.payers.map((p) => p.participant),
     ...expenseFormValues.paidFor.map((p) => p.participant),
   ]) {
     if (!group.participants.some((p) => p.id === participant))
@@ -207,7 +215,14 @@ export async function updateExpense(
       amount: expenseFormValues.amount,
       title: expenseFormValues.title,
       categoryId: expenseFormValues.category,
-      paidById: expenseFormValues.paidBy,
+      paidById: expenseFormValues.payers[0].participant,
+      payers: {
+        deleteMany: {},
+        create: expenseFormValues.payers.map((payer) => ({
+          participantId: payer.participant,
+          amount: payer.amount,
+        })),
+      },
       splitMode: expenseFormValues.splitMode,
       recurrenceRule: expenseFormValues.recurrenceRule,
       paidFor: {
@@ -344,6 +359,12 @@ export async function getGroupExpenses(
       id: true,
       isReimbursement: true,
       paidBy: { select: { id: true, name: true } },
+      payers: {
+        select: {
+          participant: { select: { id: true, name: true } },
+          amount: true,
+        },
+      },
       paidFor: {
         select: {
           participant: { select: { id: true, name: true } },
@@ -376,6 +397,7 @@ export async function getExpense(groupId: string, expenseId: string) {
     where: { id: expenseId },
     include: {
       paidBy: true,
+      payers: { include: { participant: true } },
       paidFor: true,
       category: true,
       documents: true,

--- a/src/lib/balances.ts
+++ b/src/lib/balances.ts
@@ -1,5 +1,4 @@
-import { getGroupExpenses } from '@/lib/api'
-import { Participant } from '@prisma/client'
+import { Participant, SplitMode } from '@prisma/client'
 import { match } from 'ts-pattern'
 
 export type Balances = Record<
@@ -7,23 +6,40 @@ export type Balances = Record<
   { paid: number; paidFor: number; total: number }
 >
 
+type Expense = {
+  amount: number
+  paidBy: { id: string }
+  payers: { participant: { id: string }; amount: number }[]
+  paidFor: { participant: { id: string }; shares: number }[]
+  splitMode: SplitMode
+  isReimbursement: boolean
+}
+
 export type Reimbursement = {
   from: Participant['id']
   to: Participant['id']
   amount: number
 }
 
-export function getBalances(
-  expenses: NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>,
-): Balances {
+export function getBalances(expenses: Expense[]): Balances {
   const balances: Balances = {}
 
   for (const expense of expenses) {
-    const paidBy = expense.paidBy.id
     const paidFors = expense.paidFor
 
-    if (!balances[paidBy]) balances[paidBy] = { paid: 0, paidFor: 0, total: 0 }
-    balances[paidBy].paid += expense.amount
+    if (expense.payers.length > 0) {
+      for (const payer of expense.payers) {
+        const payerId = payer.participant.id
+        if (!balances[payerId])
+          balances[payerId] = { paid: 0, paidFor: 0, total: 0 }
+        balances[payerId].paid += payer.amount
+      }
+    } else {
+      const paidBy = expense.paidBy.id
+      if (!balances[paidBy])
+        balances[paidBy] = { paid: 0, paidFor: 0, total: 0 }
+      balances[paidBy].paid += expense.amount
+    }
 
     const totalPaidForShares = paidFors.reduce(
       (sum, paidFor) => sum + paidFor.shares,

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -54,7 +54,26 @@ export const expenseFormSchema = z
       )
       .refine((amount) => amount != 0, 'amountNotZero')
       .refine((amount) => amount <= 10_000_000_00, 'amountTenMillion'),
-    paidBy: z.string({ required_error: 'paidByRequired' }),
+    payers: z
+      .array(
+        z.object({
+          participant: z.string(),
+          amount: z.union([
+            z.number(),
+            z.string().transform((value, ctx) => {
+              const normalizedValue = value.replace(/,/g, '.')
+              const valueAsNumber = Number(normalizedValue)
+              if (Number.isNaN(valueAsNumber))
+                ctx.addIssue({
+                  code: z.ZodIssueCode.custom,
+                  message: 'invalidNumber',
+                })
+              return Math.round(valueAsNumber * 100)
+            }),
+          ]),
+        }),
+      )
+      .min(1, 'paidByRequired'),
     paidFor: z
       .array(
         z.object({
@@ -112,6 +131,22 @@ export const expenseFormSchema = z
       .default('NONE'),
   })
   .superRefine((expense, ctx) => {
+    const payerSum = expense.payers.reduce(
+      (total, { amount }) =>
+        total +
+        (typeof amount === 'number'
+          ? amount
+          : Math.round(Number(amount) * 100)),
+      0,
+    )
+    if (payerSum !== expense.amount) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'amountSum',
+        path: ['payers'],
+      })
+    }
+
     let sum = 0
     for (const { shares } of expense.paidFor) {
       sum +=

--- a/src/lib/totals.ts
+++ b/src/lib/totals.ts
@@ -1,8 +1,15 @@
-import { getGroupExpenses } from '@/lib/api'
+import { SplitMode } from '@prisma/client'
 
-export function getTotalGroupSpending(
-  expenses: NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>,
-): number {
+type Expense = {
+  amount: number
+  paidBy: { id: string }
+  payers: { participant: { id: string }; amount: number }[]
+  paidFor: { participant: { id: string }; shares: number }[]
+  splitMode: SplitMode
+  isReimbursement: boolean
+}
+
+export function getTotalGroupSpending(expenses: Expense[]): number {
   return expenses.reduce(
     (total, expense) =>
       expense.isReimbursement ? total : total + expense.amount,
@@ -12,18 +19,19 @@ export function getTotalGroupSpending(
 
 export function getTotalActiveUserPaidFor(
   activeUserId: string | null,
-  expenses: NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>,
+  expenses: Expense[],
 ): number {
-  return expenses.reduce(
-    (total, expense) =>
-      expense.paidBy.id === activeUserId && !expense.isReimbursement
-        ? total + expense.amount
-        : total,
-    0,
-  )
+  return expenses.reduce((total, expense) => {
+    if (expense.isReimbursement) return total
+    if (expense.payers.length > 0) {
+      const payerTotal = expense.payers
+        .filter((p) => p.participant.id === activeUserId)
+        .reduce((sum, p) => sum + p.amount, 0)
+      return total + payerTotal
+    }
+    return expense.paidBy.id === activeUserId ? total + expense.amount : total
+  }, 0)
 }
-
-type Expense = NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>[number]
 
 export function calculateShare(
   participantId: string | null,
@@ -67,7 +75,7 @@ export function calculateShare(
 
 export function getTotalActiveUserShare(
   activeUserId: string | null,
-  expenses: NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>,
+  expenses: Expense[],
 ): number {
   const total = expenses.reduce(
     (sum, expense) => sum + calculateShare(activeUserId, expense),


### PR DESCRIPTION
## Summary
- introduce `payers` array in expense form schema to capture each contributor
- persist multiple payers when creating or updating expenses and set the primary payer id
- add a "Paid by" section in the expense form for selecting contributors and amounts

## Testing
- `npx prisma generate`
- `npm run lint`
- `npm run check-types`
- `npm test`
- `npm run check-formatting`


------
https://chatgpt.com/codex/tasks/task_e_68a8454dec8483328fca4fedb1f92e8b